### PR TITLE
fixed RN0.27 deprecation of DeviceEventEmitter for keyboard events

### DIFF
--- a/src/KeyboardAwareBase.js
+++ b/src/KeyboardAwareBase.js
@@ -2,7 +2,7 @@
 import React , { Component, PropTypes } from 'react';
 
 import ReactNative, {
-  DeviceEventEmitter,
+  Keyboard,
   NativeModules
 } from 'react-native';
 
@@ -23,8 +23,8 @@ export default class KeyboardAwareBase extends Component {
   
   _addKeyboardEventListeners() {
     this.keyboardEventListeners = [
-      DeviceEventEmitter.addListener('keyboardWillShow', this._onKeyboardWillShow),
-      DeviceEventEmitter.addListener('keyboardWillHide', this._onKeyboardWillHide)
+      Keyboard.addListener('keyboardWillShow', this._onKeyboardWillShow),
+      Keyboard.addListener('keyboardWillHide', this._onKeyboardWillHide)
     ];
   }
   


### PR DESCRIPTION
See https://github.com/facebook/react-native/releases/tag/v0.27.0.
Fixes #10