### PR TITLE
Bugfix: Doesn't crash if reference doesn't exist.

### DIFF
--- a/src/KeyboardAwareBase.js
+++ b/src/KeyboardAwareBase.js
@@ -78,7 +78,7 @@ export default class KeyboardAwareBase extends Component {
     if (this.props.getTextInputRefs) {
       const textInputRefs = this.props.getTextInputRefs();
       textInputRefs.forEach((textInputRef) => {
-        if (textInputRef.isFocused()) {
+        if (textInputRef && textInputRef.isFocused()) {
           this._keyboardAwareView.getScrollResponder().scrollResponderScrollNativeHandleToKeyboard(
               ReactNative.findNodeHandle(textInputRef), 50 + (this.props.scrollOffset || 0), true);
         }


### PR DESCRIPTION
In case an earlier KeyboardAwareScrollView is still active, it may cause textInputRefs to be an array of undefined. This should fix that issue.

In more detail, the error that occurred to me was that I was using https://github.com/wix/react-native-navigation and the KeyboardAwareScrollView from an earlier page was still responding to scroll events and hence passing an array of 'undefined's . This fixed it for me.