### PR TITLE
Added scrollTo

### DIFF
--- a/src/KeyboardAwareBase.js
+++ b/src/KeyboardAwareBase.js
@@ -130,6 +130,9 @@ export default class KeyboardAwareBase extends Component {
       this._keyboardAwareView.scrollTo({x: 0, y: bottomYOffset, animated: scrollAnimated});
     }
   }
+  scrollTo(options) {
+    if (this._keyboardAwareView) this._keyboardAwareView.scrollTo(options);
+  }
 }
 
 KeyboardAwareBase.propTypes = {


### PR DESCRIPTION
I added this on my fork for use in my project, and also saw a question about it [here](https://github.com/wix/react-native-keyboard-aware-scrollview/issues/16)

Adds support for the native scrollTo method