### PR TITLE
import PropTypes from ‘prop-types’

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react-native": ">=0.25.1",
-    "react": ">=0.14.5"
+    "react": ">=0.14.5",
+    "prop-types": "*"
   }
 }

--- a/src/KeyboardAwareBase.js
+++ b/src/KeyboardAwareBase.js
@@ -1,5 +1,6 @@
 
-import React , { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 import ReactNative, {
   DeviceEventEmitter,

--- a/src/KeyboardAwareListView.js
+++ b/src/KeyboardAwareListView.js
@@ -1,5 +1,6 @@
 
-import React, {PropTypes} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   ListView

--- a/src/KeyboardAwareScrollView.js
+++ b/src/KeyboardAwareScrollView.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react';
+
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
   ScrollView


### PR DESCRIPTION
Fixes:
`Warning: PropTypes has been moved to a separate package. Accessing React.PropTypes is no longer supported and will be removed completely in React 16. Use the prop-types package on npm instead.`