### PR TITLE
only scroll back after keyboard hide if needed

### DIFF
--- a/src/KeyboardAwareBase.js
+++ b/src/KeyboardAwareBase.js
@@ -115,7 +115,10 @@ export default class KeyboardAwareBase extends Component {
 
     const hasYOffset = this._keyboardAwareView && this._keyboardAwareView.contentOffset && this._keyboardAwareView.contentOffset.y !== undefined;
     const yOffset = hasYOffset ? Math.max(this._keyboardAwareView.contentOffset.y - keyboardHeight, 0) : 0;
-    this._keyboardAwareView.scrollTo({x: 0, y: yOffset, animated: true});
+
+    if ((yOffset - keyboardHeight) > 0) {
+        this.scrollToBottom();
+    }
   }
 
   scrollBottomOnNextSizeChange() {


### PR DESCRIPTION
After keyboard did hide, it will scroll to bottom if scrollview had to be pushed up