### PR TITLE
Disable scroll when keyboard is hidden

### DIFF
--- a/src/KeyboardAwareBase.js
+++ b/src/KeyboardAwareBase.js
@@ -16,7 +16,10 @@ export default class KeyboardAwareBase extends Component {
   constructor(props) {
     super(props);
     this._bind('_onKeyboardWillShow', '_onKeyboardWillHide', '_addKeyboardEventListeners', '_removeKeyboardListeners', '_scrollToFocusedTextInput', '_onKeyboardAwareViewLayout', 'scrollToBottom', 'scrollBottomOnNextSizeChange');
-    this.state = {keyboardHeight: 0};
+    this.state = {
+      keyboardHeight: 0,
+      scrollEnabled: !props.disableScrollWhenKeyboardHidden
+    };
   }
   
   _bind(...methods) {
@@ -107,6 +110,10 @@ export default class KeyboardAwareBase extends Component {
     if(this.props.scrollToBottomOnKBShow) {
       this.scrollToBottom();
     }
+
+    if (this.props.disableScrollWhenKeyboardHidden) {
+      this.setState({scrollEnabled: true});
+    }
   }
 
   _onKeyboardWillHide(event) {
@@ -116,6 +123,10 @@ export default class KeyboardAwareBase extends Component {
     const hasYOffset = this._keyboardAwareView && this._keyboardAwareView.contentOffset && this._keyboardAwareView.contentOffset.y !== undefined;
     const yOffset = hasYOffset ? Math.max(this._keyboardAwareView.contentOffset.y - keyboardHeight, 0) : 0;
     this._keyboardAwareView.scrollTo({x: 0, y: yOffset, animated: true});
+
+    if (this.props.disableScrollWhenKeyboardHidden) {
+      this.setState({scrollEnabled: false});
+    }
   }
 
   scrollBottomOnNextSizeChange() {
@@ -142,10 +153,12 @@ export default class KeyboardAwareBase extends Component {
 KeyboardAwareBase.propTypes = {
   startScrolledToBottom: PropTypes.bool,
   scrollToBottomOnKBShow: PropTypes.bool,
-  scrollToInputAdditionalOffset: PropTypes.number
+  scrollToInputAdditionalOffset: PropTypes.number,
+  disableScrollWhenKeyboardHidden: PropTypes.bool
 };
 KeyboardAwareBase.defaultProps = {
   startScrolledToBottom: false,
   scrollToBottomOnKBShow: false,
-  scrollToInputAdditionalOffset: 75
+  scrollToInputAdditionalOffset: 75,
+  disableScrollWhenKeyboardHidden: false
 };

--- a/src/KeyboardAwareListView.js
+++ b/src/KeyboardAwareListView.js
@@ -14,6 +14,7 @@ export default class KeyboardAwareListView extends KeyboardAwareBase {
     const initialOpacity = this.props.startScrolledToBottom ? 0 : 1;
     return (
       <ListView {...this.props} {...this.style}
+        scrollEnabled={this.state.scrollEnabled}
         opacity={initialOpacity}
         contentInset={{bottom: this.state.keyboardHeight}}
         ref={(r) => {

--- a/src/KeyboardAwareScrollView.js
+++ b/src/KeyboardAwareScrollView.js
@@ -12,6 +12,7 @@ export default class KeyboardAwareScrollView extends KeyboardAwareBase {
   render() {
     return (
       <ScrollView {...this.props} {...this.style}
+        scrollEnabled={this.state.scrollEnabled}
         contentInset={{bottom: this.state.keyboardHeight}}
         ref={(r) => {
           this._keyboardAwareView = r;


### PR DESCRIPTION
In some cases, it would be good for the scroll view to behave like a normal view and not be able to scroll unless the keyboard is up.

This update adds a prop `disableScrollWhenKeyboardHidden` that adds this behaviour.