### PR TITLE
Add defensive checks before calling isFocused

### DIFF
--- a/src/KeyboardAwareBase.js
+++ b/src/KeyboardAwareBase.js
@@ -80,8 +80,8 @@ export default class KeyboardAwareBase extends Component {
   _scrollToFocusedTextInput() {
     if (this.props.getTextInputRefs) {
       const textInputRefs = this.props.getTextInputRefs();
-      textInputRefs.some((textInputRef, index, array) => {
-        const isFocusedFunc = textInputRef.isFocused();
+      textInputRefs.some((textInputRef) => {
+        const isFocusedFunc = textInputRef && (typeof textInputRef.isFocused === "function") && textInputRef.isFocused();
         const isFocused = isFocusedFunc && (typeof isFocusedFunc === "function") ? isFocusedFunc() : isFocusedFunc;
         if (isFocused) {
           setTimeout(() => {


### PR DESCRIPTION
When making use of useRef for refs forwarded to a custom functional
component there is potential for the isFocused function not to be
defined. Adding some extra checks to make sure that it is a function
before calling it prevents an error from being thrown.