### PR TITLE
Fix type error when navigating with the keyboard open

### DIFF
--- a/src/KeyboardAwareBase.js
+++ b/src/KeyboardAwareBase.js
@@ -111,7 +111,7 @@ export default class KeyboardAwareBase extends Component {
 
     const hasYOffset = this._keyboardAwareView && this._keyboardAwareView.contentOffset && this._keyboardAwareView.contentOffset.y !== undefined;
     const yOffset = hasYOffset ? Math.max(this._keyboardAwareView.contentOffset.y - keyboardHeight, 0) : 0;
-    this._keyboardAwareView.scrollTo({x: 0, y: yOffset, animated: true});
+    this._keyboardAwareView?.scrollTo({x: 0, y: yOffset, animated: true});
   }
 
   scrollBottomOnNextSizeChange() {


### PR DESCRIPTION
Navigating with react navigation with the keyboard open causes this to throw an error. This simple fix will resolve that.